### PR TITLE
_BSD_SOURCE has been deprecate in favour of _DEFAULT_SOURCE

### DIFF
--- a/mimedefang.c
+++ b/mimedefang.c
@@ -15,7 +15,7 @@
 * libmilter/README in the Sendmail 8.11 distribution.
 ***********************************************************************/
 
-#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 
 #ifdef __linux__
 /* On Linux, we need this defined to get fdopen.  On BSD, if we define

--- a/utils.c
+++ b/utils.c
@@ -12,7 +12,7 @@
 *
 ***********************************************************************/
 
-#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 
 #ifdef __linux__
 /* On Linux, we need this defined to get fdopen.  On BSD, if we define


### PR DESCRIPTION
Use _DEFAULT_SOURCE instead of _BSD_SOURCE, _BSD_SOURCE is deprecated.