### PR TITLE
Docs and minor fixes

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,11 @@ WARNING: Before upgrading MIMEDefang, please search this file for
 *** NOTE INCOMPATIBILITY ** to see if anything has changed that might
 affect your filter.
 
+2020-06-02 Bill Cole <bill@scconsult.com>
+
+    * mimedefang.pl: Added TLS support to md_check_against_smtp_server
+
+
 2018-03-21 Dianne Skoll <dfs@roaringpenguin.com>
 
 	* MIMEDefang 2.84 RELEASED

--- a/mimedefang-filter.5.in
+++ b/mimedefang-filter.5.in
@@ -477,6 +477,10 @@ in a return value of ("TEMPFAIL", $msg).
 The optional argument $port specifies the TCP port to connect to.  If
 it is not supplied, then the default SMTP port of 25 is used.
 
+If the server offers STARTTLS support, TLS step-up is attempted. If TLS 
+step-up fails, the check will fall-back to using clear text and log the 
+failure
+
 .PP
 Suppose the machine \fBfilter.domain.tld\fR is filtering mail destined
 for the real mail server \fBmail.domain.tld\fR.  You could have a

--- a/mimedefang.pl.in
+++ b/mimedefang.pl.in
@@ -7418,10 +7418,11 @@ sub get_smtp_return_code {
 #  sock -- a socket connected to an SMTP server
 #  server -- the server we're querying
 # %RETURNS:
-#  A four-element list:(retval, code, dsn, @exts)
-#  where code is a 3-digit SMTP code.
-#  and @exts is a hash of EXTNAME->EXTOPTS
-#  Retval is 'CONTINUE', 'TEMPFAIL' or 'REJECT'.
+#  A four-element list:(retval, code, dsn, exts)
+#  retval is 'CONTINUE', 'TEMPFAIL' or 'REJECT'.
+#  code is a 3-digit SMTP code.
+#  dsn is an extended SMTP status code
+#  exts is a hash of EXTNAME->EXTOPTS
 # %DESCRIPTION:
 #  Checks SMTP server's supported extensions. 
 #  Expects EHLO to have been sent already (artifact of cribbing get_smtp_return_code)
@@ -7458,7 +7459,7 @@ sub get_smtp_extensions {
 
     $code =~ m/2../ and return ('CONTINUE', "$code", "2.5.0", %exts );
     $code =~ m/4../ and return ('TEMPFAIL', "$code", "4.0.0", %exts );
-    $code =~ m/5../ and return ('PERMFAIL', "$code", "5.0.0", %exts );
+    $code =~ m/5../ and return ('REJECT', "$code", "5.0.0", %exts );
 }
 
 
@@ -7560,6 +7561,7 @@ sub md_check_against_smtp_server {
           $sock->print("EHLO $helo\r\n");
           } else {
           #back off from using STARTTLS
+          no warnings 'once';
           md_syslog('debug',"md_check_against_smtp_server: $server offers STARTTLS but fails with error $IO::Socket::SSL::SSL_ERROR. Falling back to plaintext...");
           $sock->print("EHLO $helo\r\n");
        }


### PR DESCRIPTION
Normalized comment block for get_smtp_extensions() and corrected 5xy text retval.
Silenced 'used only once' warning in md_check_against_smtp_server().
Documented md_check_against_smtp_server() TLS behavior.
Added Changelog entry for md_check_against_smtp_server() TLS support.