### PR TITLE
Fixed URL of MIMEDefang-HOWTO

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ MIMEDefang has the following software requirements:
 ---------------
 
 There's an excellent MIMEDefang-HOWTO contributed by Mickey Hill
-at http://www.rudolphtire.com/mimedefang-howto/.  It explains
+at http://www.mickeyhill.com/mimedefang-howto/.  It explains
 everything in this README in much greater detail.  Anyway, on with it:
 
 1) Sendmail


### PR DESCRIPTION
The URL to the MIMEDefang-HOWTO contributed by Mickey Hill in the readme was broken, fixed it with the working URL to the web page operated by Mickey Hill