### PR TITLE
Don't think rspamc is installed when it isn't

### DIFF
--- a/mimedefang.pl.in
+++ b/mimedefang.pl.in
@@ -7829,7 +7829,7 @@ sub rspamd_check {
         return undef;
     }
     # forking method is deprecated
-    if(defined $Features{"Path:RSPAMC"}) {
+    if($Features{"Path:RSPAMC"}) {
       md_syslog("Warning", "Using fork method to check Rspamd server (deprecated)");
       $rspamc = 0;
     }


### PR DESCRIPTION
The flags code at the top of the script sets
`$Features{"Path:RSPAMC"}` to `0`, not `undef`, if the path isn't
known. Therefore, to test whether we know the path, we just need to
test whether `$Features{"Path:RSPAMC"}` is trueish, not whether it's
defined.