### PR TITLE
Skip DNS tests without network access

### DIFF
--- a/t/net.t
+++ b/t/net.t
@@ -55,7 +55,13 @@ sub t_reverse_ip : Test(2)
 sub t_get_ptr_record : Test(1)
 {
   my $ipv4 = '1.1.1.1';
-  is(Mail::MIMEDefang::Net::get_ptr_record($ipv4), 'one.one.one.one');
+
+  SKIP: {
+    if ( (not defined $ENV{'NET_TEST'}) or ($ENV{'NET_TEST'} ne 'yes' )) {
+      skip "Net test disabled", 1
+    }
+    is(Mail::MIMEDefang::Net::get_ptr_record($ipv4), 'one.one.one.one');
+  }
 }
 
 sub t_relay_is_blacklisted_multi : Test(1)
@@ -107,15 +113,27 @@ sub t_email_is_blacklisted : Test(1)
 sub t_md_get_bogus_mx_hosts : Test(1)
 {
   my $domain = 'multihomed.dnsbltest.spamassassin.org';
-  my @res = md_get_bogus_mx_hosts($domain);
-  is(scalar @res, 1);
+
+  SKIP: {
+    if ( (not defined $ENV{'NET_TEST'}) or ($ENV{'NET_TEST'} ne 'yes' )) {
+      skip "Net test disabled", 1
+    }
+    my @res = md_get_bogus_mx_hosts($domain);
+    is(scalar @res, 1);
+  }
 }
 
 sub t_get_mx_ip_addresses : Test(1)
 {
   my $domain = 'mimedefang.org';
-  my @res = get_mx_ip_addresses($domain);
-  is(scalar @res, 2);
+
+  SKIP: {
+    if ( (not defined $ENV{'NET_TEST'}) or ($ENV{'NET_TEST'} ne 'yes' )) {
+      skip "Net test disabled", 1
+    }
+    my @res = get_mx_ip_addresses($domain);
+    is(scalar @res, 2);
+  }
 }
 
 __PACKAGE__->runtests();


### PR DESCRIPTION
Building MIMEDefang 3.6 in a sealed build environment, like the Fedora build system, fails during tests like this:

```
$ make test
prove -It/lib --recurse t
t/actions.t ... ok
t/antispam.t .. ok
t/arc.t ....... ok
t/authres.t ... ok
t/core.t ...... ok
t/critic.t .... skipped: Author test.  Set $ENV{TEST_AUTHOR} to a true value to run. t/dates.t ..... ok
t/dkim.t ...... ok
t/headers.t ... ok
t/mime.t ...... ok
t/net.t .......
Dubious, test returned 3 (wstat 768, 0x300)
Failed 3/15 subtests
	(less 3 skipped subtests: 9 okay)
t/relay.t ..... ok
t/sender.t .... ok
t/smtp.t ...... ok
t/spf.t ....... ok
t/utils.t ..... ok
Test Summary Report
-------------------
t/net.t     (Wstat: 768 (exited 3) Tests: 15 Failed: 3)
  Failed tests:  5-6, 11
  Non-zero exit status: 3
Files=16, Tests=130, 680 wallclock secs ( 0.05 usr  0.03 sys +  3.91 cusr  0.71 csys =  4.70 CPU)
Result: FAIL
make: *** [Makefile:365: test] Error 1
```